### PR TITLE
add rust syntax highlighting

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -59,6 +59,7 @@ module.exports = {
     prism: {
       theme: lightCodeTheme,
       darkTheme: darkCodeTheme,
+      additionalLanguages: ['rust'],
     },
   },
   presets: [


### PR DESCRIPTION
Adds syntax highlighting for rust lang.
Based on [docusaurus docs](https://docusaurus.io/docs/markdown-features/code-blocks#supported-languages)